### PR TITLE
Remove Phase X references from code comments

### DIFF
--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -1,5 +1,5 @@
 /**
- * AI Agent module - Phase 4
+ * AI Agent module
  *
  * Provides AI-powered documentation generation using OpenAI or Gemini APIs
  */

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for AI Agent module (Phase 4)
+ * Type definitions for AI Agent module
  */
 
 import { CodeSignature } from '../core/types';

--- a/src/cli/fix.ts
+++ b/src/cli/fix.ts
@@ -3,8 +3,8 @@
  *
  * Fixes documentation drift by updating Markdown files with AI-generated content
  *
- * Phase 3: Manual content updates (placeholder)
- * Phase 4: AI-powered documentation generation (OpenAI, Gemini)
+ * Manual content updates (placeholder)
+ * AI-powered documentation generation (OpenAI, Gemini)
  */
 
 import { DoctypeMapManager } from '../content/map-manager';
@@ -117,7 +117,7 @@ export async function fixCommand(options: FixOptions): Promise<FixResult> {
   logger.newline();
   logger.divider();
 
-  // Initialize AI Agent if API key is available (Phase 4)
+  // Initialize AI Agent if API key is available
   let aiAgent: AIAgent | null = null;
   let useAI = false;
 
@@ -159,7 +159,7 @@ export async function fixCommand(options: FixOptions): Promise<FixResult> {
     try {
       let newContent: string;
 
-      // Phase 4: Use AI Agent if available
+      // Use AI Agent if available
       if (useAI && aiAgent) {
         logger.debug('Generating AI-powered documentation...');
 
@@ -195,7 +195,7 @@ export async function fixCommand(options: FixOptions): Promise<FixResult> {
           newContent = generatePlaceholderContent(entry.codeRef.symbolName, currentSignature.signatureText);
         }
       } else {
-        // Phase 3: Simple placeholder content
+        // Simple placeholder content
         newContent = generatePlaceholderContent(entry.codeRef.symbolName, currentSignature.signatureText);
         logger.debug(`Generated placeholder content (${newContent.length} chars)`);
       }
@@ -211,7 +211,7 @@ export async function fixCommand(options: FixOptions): Promise<FixResult> {
         successCount++;
         logger.success(`Updated documentation (${result.linesChanged} lines changed)`);
 
-        // Update the map with new hash and signature text (Phase 4)
+        // Update the map with new hash and signature text
         if (!options.dryRun) {
           const newHash = hasher.hash(currentSignature).hash;
           mapManager.updateEntry(entry.id, {
@@ -279,7 +279,7 @@ export async function fixCommand(options: FixOptions): Promise<FixResult> {
   if (options.dryRun) {
     logger.info('Dry run complete - no files were modified');
   } else if (options.autoCommit && successCount > 0) {
-    // Phase 4: Auto-commit functionality
+    // Auto-commit functionality
     logger.newline();
     logger.info('Auto-committing changes...');
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,7 @@
  * - check: Verify documentation is in sync with code
  * - fix: Update documentation when drift is detected (with AI-powered generation)
  *
- * Phase 4: Now with AI-powered documentation generation using OpenAI or Gemini APIs
+ * Now with AI-powered documentation generation using OpenAI or Gemini APIs
  */
 
 // Load environment variables from .env file

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -120,7 +120,7 @@ export interface FixOptions {
   autoCommit?: boolean;
   /** Interactive mode (prompt before each fix) */
   interactive?: boolean;
-  /** Disable AI-generated content (use placeholder instead) - Phase 4 */
+  /** Disable AI-generated content (use placeholder instead) */
   noAI?: boolean;
 }
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 2 - Content & Mapping Module
+ * Content & Mapping Module
  *
  * This module handles:
  * - Markdown parsing and anchor extraction

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -73,7 +73,7 @@ export interface DoctypeMapEntry {
   codeRef: CodeRef;
   /** Hash of the code signature */
   codeSignatureHash: string;
-  /** The signature text (added in Phase 4 for AI context) */
+  /** The signature text (for AI context) */
   codeSignatureText?: string;
   /** Reference to the documentation */
   docRef: DocRef;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Main entry point for the Doctype library
  */
 
-// Phase 1: Core AST & Drift Detection
+// Core AST & Drift Detection
 export { ASTAnalyzer } from './core/ast-analyzer';
 export { SignatureHasher } from './core/signature-hasher';
 export { SymbolType } from './core/types';
@@ -17,11 +17,11 @@ export type {
   DoctypeMap,
 } from './core/types';
 
-// Phase 2: Content & Mapping
+// Content & Mapping
 export { MarkdownParser, DoctypeMapManager, ContentInjector } from './content';
 export type { DoctypeAnchor, InjectionResult } from './content';
 
-// Phase 4: Gen AI Agent
+// Gen AI Agent
 export { AIAgent, createOpenAIAgent, createAgentFromEnv, PromptBuilder } from './ai';
 export type {
   AIProvider,


### PR DESCRIPTION
## Summary
- Removed all "Phase X -" and "Phase X:" prefixes from code comments
- Cleaned up 8 files across src/ai, src/cli, src/content, and src/core directories
- Updated module documentation to remove project phase references

## Changes Made
- **src/ai/index.ts**: Removed "Phase 4" from module comment
- **src/ai/types.ts**: Removed "Phase 4" from type definitions comment
- **src/cli/fix.ts**: Removed multiple Phase references (3, 4) from inline comments
- **src/cli/index.ts**: Removed "Phase 4:" from main entry point comment
- **src/cli/types.ts**: Removed "Phase 4" from interface comment
- **src/content/index.ts**: Removed "Phase 2 -" from module comment
- **src/core/types.ts**: Removed "Phase 4" from type definition comment
- **src/index.ts**: Removed "Phase 1:", "Phase 2:", and "Phase 4:" from export section comments

## Test Plan
- Verified all Phase references removed using grep search
- No functional code changes, only documentation/comment updates
- All changes are comment-only modifications

Fixes #30