### PR TITLE
fix(ci): add Rust build step to CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           node-version: '20' # Using Node.js 20, which is a recent LTS version
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust core types
+        run: |
+          cd crates/core
+          npm install
+          npm run build
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,17 @@ jobs:
         if: steps.bump.outputs.type
         run: npm install -g npm@latest
 
+      - name: Setup Rust
+        if: steps.bump.outputs.type
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Rust core types
+        if: steps.bump.outputs.type
+        run: |
+          cd crates/core
+          npm install
+          npm run build
+
       - name: Install dependencies
         if: steps.bump.outputs.type
         run: npm ci


### PR DESCRIPTION
Add Rust toolchain setup and core package build steps before tests to ensure @doctypedev/core is available when running tests in CI.

Changes:
- Add Setup Rust step using dtolnay/rust-toolchain@stable
- Add Build Rust core types step to generate index.js and index.d.ts
- Execute before npm ci to ensure package is built before linking

This fixes test failures in CI where Vite could not resolve @doctypedev/core package entry points.

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)