### PR TITLE
fix(publish): move @doctypedev/core to devDependencies and exclude crates from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -62,6 +62,9 @@ lerna-debug.log*
 # Dependencies
 node_modules/
 
+# Rust crates (development only, not needed in published package)
+crates/
+
 # Build artifacts
 *.tsbuildinfo
 .cache/

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "license": "MIT",
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "@doctypedev/core": "file:./crates/core",
     "@types/uuid": "^10.0.0",
     "dotenv": "^17.2.3",
     "ts-morph": "^21.0.1",
@@ -51,6 +50,7 @@
     "@doctypedev/core-darwin-arm64": "^0.3.10"
   },
   "devDependencies": {
+    "@doctypedev/core": "file:./crates/core",
     "@types/node": "^20.10.6",
     "@types/vue": "^1.0.31",
     "@types/yargs": "^17.0.32",


### PR DESCRIPTION
- Move @doctypedev/core from dependencies to devDependencies to avoid 'Hard link is not allowed' error
- Add crates/ to .npmignore to exclude development-only Rust code from published package
- Types are only needed during development/build, runtime uses platform-specific packages