### PR TITLE
feat(publish): auto-sync optionalDependencies versions in publish workflow

### DIFF
--- a/crates/core/scripts/sync-version.js
+++ b/crates/core/scripts/sync-version.js
@@ -39,4 +39,29 @@ for (const platform of platforms) {
   }
 }
 
-console.log(`\n✨ Updated ${updated} package(s)`);
+// Update optionalDependencies in main package.json
+console.log(`\n📝 Updating optionalDependencies in main package.json...`);
+
+let mainUpdated = false;
+if (mainPackage.optionalDependencies) {
+  for (const [depName, depVersion] of Object.entries(mainPackage.optionalDependencies)) {
+    // Only update @doctypedev/core-* packages
+    if (depName.startsWith('@doctypedev/core-')) {
+      const expectedVersion = `^${version}`;
+      if (depVersion !== expectedVersion) {
+        mainPackage.optionalDependencies[depName] = expectedVersion;
+        console.log(`✅ Updated ${depName}: ${depVersion} → ${expectedVersion}`);
+        mainUpdated = true;
+      } else {
+        console.log(`⏭️  ${depName}: already at ${expectedVersion}`);
+      }
+    }
+  }
+
+  if (mainUpdated) {
+    fs.writeFileSync(mainPackagePath, JSON.stringify(mainPackage, null, 2) + '\n');
+    console.log(`✅ Main package.json updated`);
+  }
+}
+
+console.log(`\n✨ Updated ${updated} platform package(s)${mainUpdated ? ' and main package.json' : ''}`);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "yargs": "^17.7.2"
   },
   "optionalDependencies": {
-    "@doctypedev/core-darwin-arm64": "^0.3.10"
+    "@doctypedev/core-darwin-arm64": "^0.3.21"
   },
   "devDependencies": {
     "@doctypedev/core": "file:./crates/core",


### PR DESCRIPTION
- Extend sync-version.js to automatically update optionalDependencies
- Ensures @doctypedev/core-* packages stay in sync with main version
- Updates package.json optionalDependencies to ^0.3.21
- Maintains version consistency across all platform packages