### PR TITLE
feat(core): implement Rust file discovery and separate CLI/Core layers

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 # napi-rs for Node.js bindings
 napi = { version = "2", features = ["async"] }
 napi-derive = "2"
+ignore = "0.4.25"
 
 # Future dependencies:
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/core/src/discovery.rs
+++ b/crates/core/src/discovery.rs
@@ -1,0 +1,297 @@
+//! File discovery module for scanning codebases
+//!
+//! This module provides functionality to discover and categorize files in a directory tree.
+//! It can find TypeScript/JavaScript source files and Markdown documentation files while
+//! respecting .gitignore rules and providing flexible configuration options.
+
+use ignore::{Walk, WalkBuilder};
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
+/// Represents a discovered file in the codebase
+#[derive(Debug, Clone)]
+pub enum DiscoveredFile {
+    /// Markdown documentation file (.md, .mdx)
+    Markdown(PathBuf),
+    /// TypeScript/JavaScript source file (.ts, .tsx, .js, .jsx, .mts, .cts)
+    Source(PathBuf),
+}
+
+impl DiscoveredFile {
+    /// Get the path of the discovered file
+    pub fn path(&self) -> &PathBuf {
+        match self {
+            DiscoveredFile::Markdown(p) | DiscoveredFile::Source(p) => p,
+        }
+    }
+
+    /// Check if this is a markdown file
+    pub fn is_markdown(&self) -> bool {
+        matches!(self, DiscoveredFile::Markdown(_))
+    }
+
+    /// Check if this is a source file
+    pub fn is_source(&self) -> bool {
+        matches!(self, DiscoveredFile::Source(_))
+    }
+}
+
+/// Configuration options for file discovery
+#[derive(Debug, Clone)]
+pub struct DiscoveryConfig {
+    /// Follow .gitignore rules
+    pub respect_gitignore: bool,
+    /// Include hidden files (starting with .)
+    pub include_hidden: bool,
+    /// Maximum depth to traverse (None = unlimited)
+    pub max_depth: Option<usize>,
+    /// Include additional file extensions for source files
+    pub custom_source_extensions: Vec<String>,
+    /// Include additional file extensions for markdown files
+    pub custom_markdown_extensions: Vec<String>,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            respect_gitignore: true,
+            include_hidden: false,
+            max_depth: None,
+            custom_source_extensions: vec![],
+            custom_markdown_extensions: vec![],
+        }
+    }
+}
+
+impl DiscoveryConfig {
+    /// Create a new configuration with default values
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set whether to respect .gitignore files
+    pub fn respect_gitignore(mut self, value: bool) -> Self {
+        self.respect_gitignore = value;
+        self
+    }
+
+    /// Set whether to include hidden files
+    pub fn include_hidden(mut self, value: bool) -> Self {
+        self.include_hidden = value;
+        self
+    }
+
+    /// Set maximum traversal depth
+    pub fn max_depth(mut self, depth: usize) -> Self {
+        self.max_depth = Some(depth);
+        self
+    }
+
+    /// Add custom source file extensions
+    pub fn add_source_extension(mut self, ext: impl Into<String>) -> Self {
+        self.custom_source_extensions.push(ext.into());
+        self
+    }
+
+    /// Add custom markdown file extensions
+    pub fn add_markdown_extension(mut self, ext: impl Into<String>) -> Self {
+        self.custom_markdown_extensions.push(ext.into());
+        self
+    }
+}
+
+/// File discovery iterator for traversing a codebase
+pub struct FileCollector {
+    walker: Walk,
+    config: DiscoveryConfig,
+    stats: DiscoveryStats,
+}
+
+/// Statistics collected during file discovery
+#[derive(Debug, Clone, Default)]
+pub struct DiscoveryStats {
+    pub markdown_files: usize,
+    pub source_files: usize,
+    pub errors: usize,
+    pub skipped_dirs: usize,
+}
+
+/// Result of a file discovery operation
+#[derive(Debug, Clone)]
+pub struct DiscoveryResult {
+    /// Paths to discovered markdown files
+    pub markdown_files: Vec<PathBuf>,
+    /// Paths to discovered source files
+    pub source_files: Vec<PathBuf>,
+    /// Statistics about the discovery operation
+    pub stats: DiscoveryStats,
+}
+
+impl FileCollector {
+    /// Create a new file collector with default configuration
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self::with_config(root, DiscoveryConfig::default())
+    }
+
+    /// Create a new file collector with custom configuration
+    pub fn with_config(root: impl Into<PathBuf>, config: DiscoveryConfig) -> Self {
+        let mut builder = WalkBuilder::new(root.into());
+
+        builder
+            .hidden(!config.include_hidden)
+            .git_ignore(config.respect_gitignore)
+            .git_global(config.respect_gitignore)
+            .git_exclude(config.respect_gitignore);
+
+        if let Some(depth) = config.max_depth {
+            builder.max_depth(Some(depth));
+        }
+
+        let walker = builder.build();
+
+        Self {
+            walker,
+            config,
+            stats: DiscoveryStats::default(),
+        }
+    }
+
+    /// Get the current discovery statistics
+    pub fn stats(&self) -> &DiscoveryStats {
+        &self.stats
+    }
+
+    /// Check if a file extension is a source file
+    fn is_source_extension(&self, ext: &str) -> bool {
+        matches!(ext, "ts" | "tsx" | "js" | "jsx" | "mts" | "cts" | "mjs" | "cjs")
+            || self.config.custom_source_extensions.iter().any(|e| e == ext)
+    }
+
+    /// Check if a file extension is a markdown file
+    fn is_markdown_extension(&self, ext: &str) -> bool {
+        matches!(ext, "md" | "mdx")
+            || self.config.custom_markdown_extensions.iter().any(|e| e == ext)
+    }
+}
+
+/// Implementing Iterator allows us to use `for file in collector { ... }`
+impl Iterator for FileCollector {
+    type Item = DiscoveredFile;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(result) = self.walker.next() {
+            match result {
+                Ok(entry) => {
+                    let path = entry.path();
+
+                    // Skip directories
+                    if path.is_dir() {
+                        self.stats.skipped_dirs += 1;
+                        continue;
+                    }
+
+                    // Get file extension
+                    let extension = match path.extension().and_then(OsStr::to_str) {
+                        Some(ext) => ext,
+                        None => continue,
+                    };
+
+                    // Classify and return the file
+                    if self.is_markdown_extension(extension) {
+                        self.stats.markdown_files += 1;
+                        return Some(DiscoveredFile::Markdown(path.to_path_buf()));
+                    } else if self.is_source_extension(extension) {
+                        self.stats.source_files += 1;
+                        return Some(DiscoveredFile::Source(path.to_path_buf()));
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Discovery error: {}", err);
+                    self.stats.errors += 1;
+                    continue;
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Discover all files in a directory tree
+///
+/// This is a convenience function that collects all discovered files into vectors.
+/// For more control over the discovery process, use `FileCollector` directly.
+///
+/// # Arguments
+/// * `root` - The root directory to scan
+/// * `config` - Configuration options for the discovery
+///
+/// # Example
+/// ```
+/// use doctype_core::discovery::{discover_files, DiscoveryConfig};
+///
+/// let config = DiscoveryConfig::new()
+///     .respect_gitignore(true)
+///     .max_depth(5);
+///
+/// let result = discover_files("./src", config);
+/// println!("Found {} markdown files", result.markdown_files.len());
+/// println!("Found {} source files", result.source_files.len());
+/// ```
+pub fn discover_files(root: impl Into<PathBuf>, config: DiscoveryConfig) -> DiscoveryResult {
+    let mut collector = FileCollector::with_config(root, config);
+    let mut markdown_files = Vec::new();
+    let mut source_files = Vec::new();
+
+    for file in &mut collector {
+        match file {
+            DiscoveredFile::Markdown(path) => markdown_files.push(path),
+            DiscoveredFile::Source(path) => source_files.push(path),
+        }
+    }
+
+    DiscoveryResult {
+        markdown_files,
+        source_files,
+        stats: collector.stats().clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discovery_config_builder() {
+        let config = DiscoveryConfig::new()
+            .respect_gitignore(false)
+            .include_hidden(true)
+            .max_depth(5)
+            .add_source_extension("vue")
+            .add_markdown_extension("rst");
+
+        assert!(!config.respect_gitignore);
+        assert!(config.include_hidden);
+        assert_eq!(config.max_depth, Some(5));
+        assert!(config.custom_source_extensions.contains(&"vue".to_string()));
+    }
+
+    #[test]
+    fn test_discovered_file_methods() {
+        let md_file = DiscoveredFile::Markdown(PathBuf::from("test.md"));
+        assert!(md_file.is_markdown());
+        assert!(!md_file.is_source());
+
+        let ts_file = DiscoveredFile::Source(PathBuf::from("test.ts"));
+        assert!(!ts_file.is_markdown());
+        assert!(ts_file.is_source());
+    }
+
+    #[test]
+    fn test_discover_files_function() {
+        let config = DiscoveryConfig::new();
+        let result = discover_files(".", config);
+
+        // We should find at least this Rust file
+        assert!(result.source_files.len() > 0 || result.markdown_files.len() > 0);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,13 @@ use napi_derive::napi;
 pub mod types;
 pub use types::{SymbolType, CodeRef, CodeSignature, SignatureHash, DocRef, DoctypeMapEntry, DoctypeMap};
 
+// Core Rust modules (pure logic, no NAPI)
+pub mod discovery;
+pub use discovery::{
+    discover_files as discover_files_internal, DiscoveredFile, DiscoveryConfig, DiscoveryResult,
+    DiscoveryStats, FileCollector,
+};
+
 /// AST Analyzer for TypeScript/JavaScript code
 #[napi]
 pub struct AstAnalyzer {
@@ -52,4 +59,102 @@ pub fn hello_world() -> String {
 #[napi]
 pub fn get_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
+}
+
+// ============================================================================
+// NAPI Bindings for File Discovery
+// ============================================================================
+
+/// NAPI-compatible result structure for file discovery
+#[napi(object)]
+pub struct FileDiscoveryResult {
+    /// List of markdown file paths found
+    pub markdown_files: Vec<String>,
+    /// List of source file paths found
+    pub source_files: Vec<String>,
+    /// Total number of files found
+    pub total_files: u32,
+    /// Number of errors encountered
+    pub errors: u32,
+}
+
+/// NAPI-compatible options for file discovery
+#[napi(object)]
+pub struct FileDiscoveryOptions {
+    /// Respect .gitignore rules (default: true)
+    pub respect_gitignore: Option<bool>,
+    /// Include hidden files (default: false)
+    pub include_hidden: Option<bool>,
+    /// Maximum depth to traverse (default: unlimited)
+    pub max_depth: Option<u32>,
+}
+
+/// Discover files in a directory (NAPI binding for Node.js)
+///
+/// Scans the given directory and returns all markdown and source files found.
+/// Respects .gitignore by default.
+///
+/// # Arguments
+/// * `root_path` - The root directory to scan
+/// * `options` - Optional configuration for the discovery process
+///
+/// # Example (Node.js)
+/// ```javascript
+/// const { discoverFiles } = require('@doctypedev/core');
+///
+/// const result = discoverFiles('./src', {
+///   respectGitignore: true,
+///   includeHidden: false,
+///   maxDepth: 5
+/// });
+///
+/// console.log('Found', result.markdownFiles.length, 'markdown files');
+/// console.log('Found', result.sourceFiles.length, 'source files');
+/// console.log('Total:', result.totalFiles);
+/// ```
+#[napi]
+pub fn discover_files(
+    root_path: String,
+    options: Option<FileDiscoveryOptions>,
+) -> FileDiscoveryResult {
+    // Build Rust configuration from NAPI options
+    let mut config = DiscoveryConfig::new();
+
+    if let Some(opts) = options {
+        if let Some(respect_gitignore) = opts.respect_gitignore {
+            config = config.respect_gitignore(respect_gitignore);
+        }
+        if let Some(include_hidden) = opts.include_hidden {
+            config = config.include_hidden(include_hidden);
+        }
+        if let Some(max_depth) = opts.max_depth {
+            config = config.max_depth(max_depth as usize);
+        }
+    }
+
+    // Call the pure Rust function
+    let result = discover_files_internal(root_path, config);
+
+    // Convert PathBuf to String for NAPI
+    let markdown_files: Vec<String> = result
+        .markdown_files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+
+    let source_files: Vec<String> = result
+        .source_files
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+
+    let total_files = (markdown_files.len() + source_files.len()) as u32;
+
+    // Return NAPI-compatible result
+    FileDiscoveryResult {
+        markdown_files,
+        source_files,
+        total_files,
+        errors: result.stats.errors as u32,
+    }
 }

--- a/packages/cli/__tests__/init.test.ts
+++ b/packages/cli/__tests__/init.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { initCommand, determineOutputFile } from '../init';
+import { initCommand } from '../init';
+import { determineOutputFile } from '../../core/init-orchestrator';
 import { readFileSync, unlinkSync, existsSync, mkdirSync, rmdirSync, writeFileSync } from 'fs';
 import { join, resolve } from 'path';
 import { DoctypeConfig } from '../types';

--- a/packages/cli/types.ts
+++ b/packages/cli/types.ts
@@ -2,6 +2,8 @@
  * CLI-specific type definitions
  */
 
+import type { OutputStrategy } from '../core/init-orchestrator';
+
 /**
  * Result of a drift check operation
  */
@@ -161,8 +163,3 @@ export interface DoctypeConfig {
   /** Directory where the config file was found (internal use) */
   baseDir?: string;
 }
-
-/**
- * Strategy for generating documentation files
- */
-export type OutputStrategy = 'mirror' | 'module' | 'type';

--- a/packages/core/init-orchestrator.ts
+++ b/packages/core/init-orchestrator.ts
@@ -1,0 +1,311 @@
+/**
+ * Init Orchestrator - Core business logic for initialization
+ *
+ * This module contains the core logic for:
+ * - Scanning codebases for TypeScript files
+ * - Extracting symbols and generating signatures
+ * - Creating documentation anchors
+ * - Managing the doctype-map.json
+ *
+ * This is pure business logic with no CLI dependencies.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ASTAnalyzer } from './ast-analyzer';
+import { SignatureHasher } from './signature-hasher';
+import { DoctypeMapManager } from '../content/map-manager';
+import { MarkdownAnchorInserter } from '../content/markdown-anchor-inserter';
+import { DoctypeMapEntry, SymbolType, discoverFiles } from '@doctypedev/core';
+
+/**
+ * Output strategy for documentation files
+ */
+export type OutputStrategy = 'mirror' | 'module' | 'type';
+
+/**
+ * Configuration for the initialization process
+ */
+export interface InitConfig {
+  projectRoot: string;
+  docsFolder: string;
+  mapFile: string;
+  outputStrategy?: OutputStrategy;
+}
+
+/**
+ * Result of the scanning process
+ */
+export interface ScanResult {
+  totalFiles: number;
+  totalSymbols: number;
+  anchorsCreated: number;
+  filesCreated: number;
+  errors: string[];
+}
+
+/**
+ * Progress callback for reporting scan progress
+ */
+export type ProgressCallback = (message: string) => void;
+
+/**
+ * Determine the output file path based on strategy and symbol
+ */
+export function determineOutputFile(
+  strategy: OutputStrategy,
+  docsFolder: string,
+  filePath: string,
+  symbolType: SymbolType
+): string {
+  // Default to mirror if undefined
+  const effectiveStrategy = strategy || 'mirror';
+
+  if (effectiveStrategy === 'mirror') {
+    // src/auth/login.ts -> docs/src/auth/login.md
+    // We keep the full path structure to avoid collisions
+    const parsed = path.parse(filePath);
+    const dirPath = path.join(docsFolder, parsed.dir);
+    return path.join(dirPath, `${parsed.name}.md`);
+  }
+
+  if (effectiveStrategy === 'module') {
+    // src/auth/login.ts -> docs/src/auth.md
+    // src/index.ts -> docs/src.md
+    const dir = path.dirname(filePath);
+    // If file is at root (e.g. index.ts), dir is "."
+    if (dir === '.' || dir === '') {
+      return path.join(docsFolder, 'index.md');
+    }
+    return path.join(docsFolder, `${dir}.md`);
+  }
+
+  if (effectiveStrategy === 'type') {
+    switch (symbolType) {
+      case SymbolType.Class:
+        return path.join(docsFolder, 'classes.md');
+      case SymbolType.Function:
+        return path.join(docsFolder, 'functions.md');
+      case SymbolType.Interface:
+        return path.join(docsFolder, 'interfaces.md');
+      case SymbolType.TypeAlias:
+      case SymbolType.Enum:
+        return path.join(docsFolder, 'types.md');
+      case SymbolType.Variable:
+      case SymbolType.Const:
+        return path.join(docsFolder, 'variables.md');
+      default:
+        return path.join(docsFolder, 'api.md');
+    }
+  }
+
+  return path.join(docsFolder, 'api.md');
+}
+
+/**
+ * Generates a meaningful H1 title for a new Markdown documentation file
+ */
+function generateMarkdownTitle(docPath: string): string {
+  const basename = path.basename(docPath, '.md');
+
+  if (basename === 'index' || basename === 'api') {
+    return 'API Reference';
+  }
+
+  // Capitalize the first letter
+  return basename.charAt(0).toUpperCase() + basename.slice(1);
+}
+
+/**
+ * Scan codebase and create documentation anchors
+ *
+ * This is the core orchestration function that:
+ * 1. Discovers TypeScript files using Rust-powered discovery
+ * 2. Analyzes each file for exported symbols
+ * 3. Generates signature hashes
+ * 4. Creates documentation anchors in markdown files
+ * 5. Updates the doctype-map.json
+ *
+ * @param config - Configuration for the scan
+ * @param onProgress - Optional callback for progress updates
+ * @returns Scan result with statistics
+ */
+export async function scanAndCreateAnchors(
+  config: InitConfig,
+  onProgress?: ProgressCallback
+): Promise<ScanResult> {
+  const projectRoot = path.resolve(process.cwd(), config.projectRoot);
+  const docsFolder = path.resolve(process.cwd(), config.docsFolder);
+  const mapFilePath = path.resolve(process.cwd(), config.mapFile);
+
+  const result: ScanResult = {
+    totalFiles: 0,
+    totalSymbols: 0,
+    anchorsCreated: 0,
+    filesCreated: 0,
+    errors: [],
+  };
+
+  // Ensure docs folder exists
+  if (!fs.existsSync(docsFolder)) {
+    fs.mkdirSync(docsFolder, { recursive: true });
+  }
+
+  // Initialize modules
+  const analyzer = new ASTAnalyzer();
+  const hasher = new SignatureHasher();
+  const mapManager = new DoctypeMapManager(mapFilePath);
+  const anchorInserter = new MarkdownAnchorInserter();
+
+  // Find all TypeScript files using Rust-powered discovery
+  onProgress?.('Scanning TypeScript files...');
+  const discoveryResult = discoverFiles(projectRoot, {
+    respectGitignore: true,
+    includeHidden: false,
+    maxDepth: undefined, // Unlimited depth
+  });
+
+  const tsFiles = discoveryResult.sourceFiles;
+  result.totalFiles = tsFiles.length;
+
+  if (tsFiles.length === 0) {
+    onProgress?.('No TypeScript files found.');
+    return result;
+  }
+
+  onProgress?.(`Found ${tsFiles.length} TypeScript files. Analyzing...`);
+
+  // Collect all symbols
+  const symbolsToDocument: Array<{
+    filePath: string;
+    symbolName: string;
+    symbolType: SymbolType;
+    signatureText: string;
+    hash: string;
+    targetDocFile: string;
+  }> = [];
+
+  for (const tsFile of tsFiles) {
+    try {
+      const signatures = analyzer.analyzeFile(tsFile);
+      // Normalize path to use forward slashes on all platforms
+      const relativePath = path.relative(projectRoot, tsFile).split(path.sep).join('/');
+
+      for (const signature of signatures) {
+        if (signature.isExported) {
+          const hashResult = hasher.hash(signature);
+
+          const targetDocFile = determineOutputFile(
+            config.outputStrategy || 'mirror',
+            docsFolder,
+            relativePath,
+            signature.symbolType
+          );
+
+          symbolsToDocument.push({
+            filePath: relativePath,
+            symbolName: signature.symbolName,
+            symbolType: signature.symbolType,
+            signatureText: signature.signatureText,
+            hash: hashResult.hash,
+            targetDocFile,
+          });
+        }
+      }
+    } catch (error) {
+      const errorMsg = `Could not analyze ${tsFile}: ${error instanceof Error ? error.message : String(error)}`;
+      result.errors.push(errorMsg);
+      onProgress?.(errorMsg);
+    }
+  }
+
+  result.totalSymbols = symbolsToDocument.length;
+
+  if (symbolsToDocument.length === 0) {
+    onProgress?.('No exported symbols found.');
+    return result;
+  }
+
+  onProgress?.(`Found ${symbolsToDocument.length} exported symbols. Creating anchors...`);
+
+  // Group by target document
+  const symbolsByDoc = new Map<string, typeof symbolsToDocument>();
+  for (const sym of symbolsToDocument) {
+    if (!symbolsByDoc.has(sym.targetDocFile)) {
+      symbolsByDoc.set(sym.targetDocFile, []);
+    }
+    symbolsByDoc.get(sym.targetDocFile)!.push(sym);
+  }
+
+  // Process each document file
+  for (const [docPath, symbols] of symbolsByDoc.entries()) {
+    let docContent = '';
+    let isNewFile = false;
+
+    // Ensure directory exists for this doc file
+    const docDir = path.dirname(docPath);
+    if (!fs.existsSync(docDir)) {
+      fs.mkdirSync(docDir, { recursive: true });
+    }
+
+    if (fs.existsSync(docPath)) {
+      docContent = fs.readFileSync(docPath, 'utf-8');
+    } else {
+      const title = generateMarkdownTitle(docPath);
+      docContent = `# ${title}\n\nAuto-generated documentation via Doctype.\n\n`;
+      isNewFile = true;
+      result.filesCreated++;
+    }
+
+    const existingCodeRefs = anchorInserter.getExistingCodeRefs(docContent);
+    const existingSet = new Set(existingCodeRefs);
+    let hasChanges = false;
+
+    for (const symbol of symbols) {
+      const codeRef = `${symbol.filePath}#${symbol.symbolName}`;
+
+      if (existingSet.has(codeRef)) {
+        continue;
+      }
+
+      const insertResult = anchorInserter.insertIntoContent(docContent, codeRef, {
+        createSection: true,
+        placeholder: 'TODO: Add documentation for this symbol',
+      });
+
+      if (insertResult.success) {
+        docContent = insertResult.content;
+        hasChanges = true;
+
+        const mapEntry: DoctypeMapEntry = {
+          id: insertResult.anchorId,
+          codeRef: {
+            filePath: symbol.filePath,
+            symbolName: symbol.symbolName,
+          },
+          codeSignatureHash: symbol.hash,
+          codeSignatureText: symbol.signatureText,
+          docRef: {
+            filePath: path.relative(process.cwd(), docPath),
+            startLine: insertResult.location.startLine,
+            endLine: insertResult.location.endLine,
+          },
+          originalMarkdownContent: `<!-- TODO: Add documentation for this symbol -->`,
+          lastUpdated: Date.now(),
+        };
+
+        mapManager.addEntry(mapEntry);
+        result.anchorsCreated++;
+      }
+    }
+
+    if (isNewFile || hasChanges) {
+      fs.writeFileSync(docPath, docContent, 'utf-8');
+    }
+  }
+
+  mapManager.save();
+  onProgress?.(`Created ${result.anchorsCreated} anchors in ${result.filesCreated} files`);
+
+  return result;
+}

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -7,7 +7,9 @@
 // Core AST & Drift Detection
 export { ASTAnalyzer } from './core/ast-analyzer';
 export { SignatureHasher } from './core/signature-hasher';
-export { SymbolType } from '@doctypedev/core';
+export { scanAndCreateAnchors, determineOutputFile } from './core/init-orchestrator';
+export type { InitConfig, ScanResult, OutputStrategy, ProgressCallback } from './core/init-orchestrator';
+export { SymbolType, discoverFiles } from '@doctypedev/core';
 export type {
   CodeRef,
   CodeSignature,
@@ -15,6 +17,8 @@ export type {
   DocRef,
   DoctypeMapEntry,
   DoctypeMap,
+  FileDiscoveryResult,
+  FileDiscoveryOptions,
 } from '@doctypedev/core';
 
 // Content & Mapping


### PR DESCRIPTION
- Add Rust-powered file discovery with .gitignore support
  - Create init-orchestrator.ts for reusable business logic
  - Remove 200+ lines of duplicate TypeScript discovery code
  - Separate CLI (UI only) from Core (business logic)
  - Export discover_files via NAPI for Node.js