### PR TITLE
refactor: optimize doctype-map.json schema

### DIFF
--- a/.changeset/soft-webs-thank.md
+++ b/.changeset/soft-webs-thank.md
@@ -1,0 +1,21 @@
+---
+"@doctypedev/core": patch
+"@doctypedev/doctype": patch
+---
+
+Remove redundant fields from doctype-map.json to make it more robust and maintainable
+
+- Remove `originalMarkdownContent` - Content is now read from markdown files at runtime
+- Remove `startLine` and `endLine` from DocRef - Use ID-based anchor lookup instead
+- Update all TypeScript and Rust type definitions
+- Update CLI commands (check, fix, init) to use simplified schema
+- Update ContentInjector and MarkdownAnchorInserter
+- Update all tests to reflect new schema
+- Update CLAUDE.md documentation
+
+Benefits:
+- Single source of truth: Markdown files contain the actual content
+- No content duplication in map file
+- More resilient to manual markdown edits (no fragile line numbers)
+- Smaller map file size
+- Simpler architecture

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -72,14 +72,14 @@ pub struct SignatureHash {
 pub struct DocRef {
     /// Path to the markdown file
     pub file_path: String,
-    /// Line number where the anchor starts
-    pub start_line: i32,
-    /// Line number where the anchor ends
-    pub end_line: i32,
 }
 
 /**
  * Complete mapping entry in doctype-map.json
+ *
+ * Note: Content is not stored here to avoid duplication.
+ * The markdown file is the single source of truth for content.
+ * Use the anchor ID to locate content between doctype:start and doctype:end tags.
  */
 #[napi(object)]
 #[derive(Debug, Serialize)]
@@ -94,8 +94,6 @@ pub struct DoctypeMapEntry {
     pub code_signature_text: Option<String>,
     /// Reference to the documentation
     pub doc_ref: DocRef,
-    /// Original markdown content between anchors
-    pub original_markdown_content: String,
     /// Last updated timestamp
     pub last_updated: f64,
 }

--- a/packages/cli/__tests__/check.test.ts
+++ b/packages/cli/__tests__/check.test.ts
@@ -63,10 +63,7 @@ Test documentation
         codeSignatureHash: hash,
         docRef: {
           filePath: testDocFile,
-          startLine: 1,
-          endLine: 3,
         },
-        originalMarkdownContent: 'Test documentation',
         lastUpdated: Date.now(),
       });
       manager.save();

--- a/packages/cli/__tests__/fix.test.ts
+++ b/packages/cli/__tests__/fix.test.ts
@@ -83,10 +83,7 @@ Old documentation
         codeSignatureHash: oldHash,
         docRef: {
           filePath: testDocFile,
-          startLine: 1,
-          endLine: 3,
         },
-        originalMarkdownContent: 'Old documentation',
         lastUpdated: Date.now(),
       });
       manager.save();

--- a/packages/cli/check.ts
+++ b/packages/cli/check.ts
@@ -101,7 +101,6 @@ export async function checkCommand(options: CheckOptions): Promise<CheckResult> 
     symbolName: drift.entry.codeRef.symbolName,
     codeFilePath: drift.entry.codeRef.filePath,
     docFilePath: drift.entry.docRef.filePath,
-    docLine: drift.entry.docRef.startLine,
     oldHash: drift.oldHash,
     newHash: drift.currentHash,
     oldSignature: undefined, // Could be retrieved from map if needed
@@ -120,7 +119,7 @@ export async function checkCommand(options: CheckOptions): Promise<CheckResult> 
 
     for (const drift of drifts) {
       logger.log(`  ${Logger.symbol(drift.symbolName)} in ${Logger.path(drift.codeFilePath)}`);
-      logger.log(`    Doc: ${Logger.path(drift.docFilePath)}:${drift.docLine}`);
+      logger.log(`    Doc: ${Logger.path(drift.docFilePath)} (anchor: ${drift.id})`);
       logger.log(`    Old hash: ${Logger.hash(drift.oldHash)}`);
       logger.log(`    New hash: ${Logger.hash(drift.newHash)}`);
       if (options.verbose && drift.newSignature) {

--- a/packages/cli/init-orchestrator.ts
+++ b/packages/cli/init-orchestrator.ts
@@ -413,19 +413,9 @@ export async function scanAndCreateAnchors(
           codeSignatureText: symbol.signatureText,
           docRef: {
             filePath: path.relative(process.cwd(), docPath),
-            startLine: insertResult.location.startLine,
-            endLine: insertResult.location.endLine,
           },
-          originalMarkdownContent: `<!-- ${normalizedContent.substring(0, 50).replace(/\n/g, ' ')}... -->`, // Approximate original content for drift detection context
           lastUpdated: Date.now(),
         };
-
-        // Store full generated content if AI was used/available
-        if (generatedContentMap.has(codeRef)) {
-            mapEntry.originalMarkdownContent = normalizedContent;
-        } else {
-            mapEntry.originalMarkdownContent = `<!-- TODO: Add documentation for this symbol -->`;
-        }
 
         mapManager.addEntry(mapEntry);
         result.anchorsCreated++;

--- a/packages/cli/types.ts
+++ b/packages/cli/types.ts
@@ -32,8 +32,6 @@ export interface DriftDetail {
   codeFilePath: string;
   /** Documentation file path */
   docFilePath: string;
-  /** Line number in documentation */
-  docLine: number;
   /** Old signature hash */
   oldHash: string;
   /** New signature hash */

--- a/packages/content/__tests__/map-manager.test.ts
+++ b/packages/content/__tests__/map-manager.test.ts
@@ -31,10 +31,7 @@ describe('DoctypeMapManager', () => {
     codeSignatureHash: 'abc123hash',
     docRef: {
       filePath: 'docs/test.md',
-      startLine: 10,
-      endLine: 20,
     },
-    originalMarkdownContent: 'Test content',
     lastUpdated: Date.now(),
   });
 
@@ -124,13 +121,13 @@ describe('DoctypeMapManager', () => {
   describe('getEntriesByDocFile', () => {
     it('should return entries in the specified doc file', () => {
       const entry1 = createTestEntry('entry-1');
-      entry1.docRef = { filePath: 'docs/a.md', startLine: 1, endLine: 10 };
+      entry1.docRef = { filePath: 'docs/a.md' };
 
       const entry2 = createTestEntry('entry-2');
-      entry2.docRef = { filePath: 'docs/a.md', startLine: 20, endLine: 30 };
+      entry2.docRef = { filePath: 'docs/a.md' };
 
       const entry3 = createTestEntry('entry-3');
-      entry3.docRef = { filePath: 'docs/b.md', startLine: 1, endLine: 10 };
+      entry3.docRef = { filePath: 'docs/b.md' };
 
       manager.addEntry(entry1);
       manager.addEntry(entry2);
@@ -161,7 +158,7 @@ describe('DoctypeMapManager', () => {
       // Wait a bit to ensure timestamp changes
       await new Promise<void>((resolve) => {
         setTimeout(() => {
-          manager.updateEntry('update-timestamp', { originalMarkdownContent: 'new content' });
+          manager.updateEntry('update-timestamp', { codeSignatureHash: 'new-hash' });
 
           const updated = manager.getEntryById('update-timestamp');
           expect(updated?.lastUpdated).toBeGreaterThan(originalTime);

--- a/packages/content/markdown-anchor-inserter.ts
+++ b/packages/content/markdown-anchor-inserter.ts
@@ -23,11 +23,6 @@ export interface AnchorInsertionResult {
   content: string;
   /** Generated anchor ID */
   anchorId: string;
-  /** Line numbers where anchor was inserted */
-  location: {
-    startLine: number;
-    endLine: number;
-  };
   /** Error message if insertion failed */
   error?: string;
 }
@@ -77,7 +72,6 @@ export class MarkdownAnchorInserter {
         success: false,
         content: '',
         anchorId: '',
-        location: { startLine: 0, endLine: 0 },
         error: error instanceof Error ? error.message : String(error),
       };
     }
@@ -107,7 +101,6 @@ export class MarkdownAnchorInserter {
         success: false,
         content,
         anchorId: '',
-        location: { startLine: 0, endLine: 0 },
         error: `Invalid code_ref format: "${codeRef}". Expected "file_path#symbol_name"`,
       };
     }
@@ -145,7 +138,6 @@ export class MarkdownAnchorInserter {
         success: false,
         content,
         anchorId: '',
-        location: { startLine: 0, endLine: 0 },
         error: `Section "${sectionTitle}" not found and createSection is false`,
       };
     }
@@ -161,10 +153,6 @@ export class MarkdownAnchorInserter {
       '',
     ];
 
-    // Calculate line numbers (accounting for array index vs line number)
-    const startLine = insertionPoint + 3; // The actual doctype:start line
-    const endLine = insertionPoint + 5;   // The actual doctype:end line
-
     // Insert the anchor
     lines.splice(insertionPoint, 0, ...anchorLines);
 
@@ -172,7 +160,6 @@ export class MarkdownAnchorInserter {
       success: true,
       content: lines.join('\n'),
       anchorId,
-      location: { startLine, endLine },
     };
   }
 
@@ -227,7 +214,6 @@ export class MarkdownAnchorInserter {
           success: false,
           content: '',
           anchorId: '',
-          location: { startLine: 0, endLine: 0 },
           error: error instanceof Error ? error.message : String(error),
         },
       ];

--- a/packages/core/native-types.d.ts
+++ b/packages/core/native-types.d.ts
@@ -59,13 +59,13 @@ export interface SignatureHash {
 export interface DocRef {
   /** Path to the markdown file */
   filePath: string;
-  /** Line number where the anchor starts */
-  startLine: number;
-  /** Line number where the anchor ends */
-  endLine: number;
 }
 /**
  * Complete mapping entry in doctype-map.json
+ *
+ * Note: Content is not stored here to avoid duplication.
+ * The markdown file is the single source of truth for content.
+ * Use the anchor ID to locate content between doctype:start and doctype:end tags.
  */
 export interface DoctypeMapEntry {
   /** Unique identifier for this anchor */
@@ -78,8 +78,6 @@ export interface DoctypeMapEntry {
   codeSignatureText?: string;
   /** Reference to the documentation */
   docRef: DocRef;
-  /** Original markdown content between anchors */
-  originalMarkdownContent: string;
   /** Last updated timestamp */
   lastUpdated: number;
 }


### PR DESCRIPTION
Remove redundant fields from doctype-map.json to make it more robust and maintainable:

- Remove `originalMarkdownContent` - Content is now read from markdown files at runtime
- Remove `startLine` and `endLine` from DocRef - Use ID-based anchor lookup instead
- Update all TypeScript and Rust type definitions
- Update CLI commands (check, fix, init) to use simplified schema
- Update ContentInjector and MarkdownAnchorInserter
- Update all tests to reflect new schema
- Update CLAUDE.md documentation

Benefits:
- Single source of truth: Markdown files contain the actual content
- No content duplication in map file
- More resilient to manual markdown edits (no fragile line numbers)
- Smaller map file size
- Simpler architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)