### PR TITLE
feat: decouple init from AI generation and introduce generate command

### DIFF
--- a/.changeset/happy-times-open.md
+++ b/.changeset/happy-times-open.md
@@ -1,0 +1,5 @@
+---
+"@doctypedev/doctype": minor
+---
+
+Introduced doctype generate command, implemented concurrent AI processing for faster performance, and simplified the initialization workflow.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -269,16 +269,19 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
   if (doc.parameters?.length) {
     parts.push('\n**Parameters:**');
     doc.parameters.forEach(p => {
-      parts.push(`- \`${p.name}\` (\`${p.type}\`): ${p.description}`);
+      parts.push(`- lexible{p.name}lexible ( lexible{p.type}): ${p.description}`);
     });
   }
 
   if (doc.returnType) {
-    parts.push(`\n**Returns:** \`${doc.returnType.type}\` - ${doc.returnType.description}`);
+    parts.push(`\n**Returns:** lexible{doc.returnType.type}lexible - ${doc.returnType.description}`);
   }
 
   if (doc.usageExample) {
-    parts.push(`\n**Usage Example:**\n\`\`\`typescript\n${doc.usageExample}\n\`\`\`\n`);
+    parts.push(`\n**Usage Example:**\n\
+```typescript
+${doc.usageExample}
+```\n`);
   }
 
   return parts.join('\n');
@@ -297,7 +300,7 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
 
 ### INIT Flow (`npx doctype init`)
 
-**Purpose:** Initialize Doctype, scan codebase, create anchors and map
+**Purpose:** Initialize Doctype, scan codebase, and scaffold documentation files.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -307,7 +310,7 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ 2. TypeScript: InitOrchestrator                             │
-│    - Interactive prompts (docs folder, AI provider, etc.)   │
+│    - Interactive prompts (docs folder, map name, etc.)      │
 │    - Saves doctype.config.json                              │
 └────────────────┬────────────────────────────────────────────┘
                  │
@@ -335,25 +338,16 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
 │    ├─ Creates docs/ files with strategy (mirror/module/type)│
 │    ├─ Inserts anchor tags:                                  │
 │    │   <!-- doctype:start id="uuid" code_ref="..." -->      │
-│    │   TODO: Add documentation                              │
+│    │   TODO: Add documentation for this symbol              │
 │    │   <!-- doctype:end id="uuid" -->                       │
 │    └─ One anchor per exported symbol                        │
 └────────────────┬────────────────────────────────────────────┘
                  │
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 6. TypeScript: AI Agent (OPTIONAL if --ai flag)             │
-│    ├─ Batch process symbols:                                │
-│    │   AI → Structured JSON → buildMarkdown()               │
-│    ├─ Replaces "TODO" with generated documentation          │
-│    └─ Saves to .md files                                    │
-└────────────────┬────────────────────────────────────────────┘
-                 │
-                 ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 7. TypeScript: DoctypeMapManager                            │
+│ 6. TypeScript: DoctypeMapManager                            │
 │    ├─ Creates doctype-map.json                              │
-│    └─ For each anchor saves:                                │
+│    └─ For each anchor saves real hash (for drift tracking): │
 │        {                                                     │
 │          id: "uuid",                                         │
 │          codeRef: { filePath, symbolName },                 │
@@ -364,10 +358,46 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
 └─────────────────────────────────────────────────────────────┘
 ```
 
-**Key Files Created:**
-- `doctype.config.json` - Project configuration
-- `doctype-map.json` - Tracking map with hashes
-- `docs/**/*.md` - Documentation files with anchors
+### GENERATE Flow (`npx doctype generate`)
+
+**Purpose:** Generate initial documentation content using AI by finding TODO placeholders.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. User runs: npx doctype generate                          │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. TypeScript: Identify Work Items                          │
+│    ├─ Detect Drift: Hash mismatch (same as check)           │
+│    └─ Detect Placeholders:                                  │
+│         a. RUST: extractAnchors() scans Markdown            │
+│         b. TS: Checks if anchor content contains "TODO"     │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. TypeScript: FixOrchestrator (Parallel Processing)        │
+│    ├─ Uses pMap with concurrency limit (e.g., 5)            │
+│    ├─ For each item (Drift or Placeholder):                 │
+│    │   a. RUST: AstAnalyzer gets current CodeSignature      │
+│    │   b. TS: Builds Prompt (Code + Old Docs)               │
+│    │   c. TS: Calls AI Agent (OpenAI/Gemini/Anthropic)      │
+│    │   d. AI: Returns structured JSON                       │
+│    │   e. TS: Transforms JSON → Markdown                    │
+│    └─ Collects results in memory                            │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. TypeScript: ContentInjector (Atomic Writes)              │
+│    ├─ Groups results by destination file                    │
+│    ├─ Reads file ONCE                                       │
+│    ├─ Applies all anchor updates for that file              │
+│    └─ Writes file ONCE (prevents race conditions)           │
+└─────────────────────────────────────────────────────────────┘
+```
 
 ---
 
@@ -413,9 +443,12 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
 
 ---
 
+
 ### FIX Flow (`npx doctype fix`)
 
-**Purpose:** Automatically fix drift and update documentation
+**Purpose:** Automatically fix drift and update documentation.
+
+*Note: `fix` and `generate` share the same underlying `FixOrchestrator` logic.*
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -431,38 +464,22 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
                  │
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 3. TypeScript: AI Agent for each drifted symbol             │
-│    ├─ Build structured prompt:                              │
-│    │   - Old signature text                                 │
-│    │   - New signature text                                 │
-│    │   - Current documentation content                      │
-│    ├─ AI generates JSON:                                    │
-│    │   {purpose, parameters, returnType, usageExample...}   │
-│    ├─ Validate with Zod schema                              │
-│    └─ buildMarkdownFromStructure(json) → Updated Markdown   │
+│ 3. TypeScript: FixOrchestrator (Parallel Processing)        │
+│    ├─ Same parallel flow as Generate                        │
+│    ├─ Uses context of OLD signature vs NEW signature        │
+│    └─ Generates update-specific documentation               │
 └────────────────┬────────────────────────────────────────────┘
                  │
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 4. TypeScript: ContentInjector                              │
-│    ├─ Read Markdown file                                    │
-│    ├─ Locate anchor by ID                                   │
-│    ├─ Replace content between doctype:start and :end        │
-│    └─ Save updated Markdown file                            │
+│ 4. TypeScript: ContentInjector & Map Update                 │
+│    ├─ Updates Markdown files                                │
+│    └─ Updates doctype-map.json with new hashes              │
 └────────────────┬────────────────────────────────────────────┘
                  │
                  ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 5. TypeScript: Update doctype-map.json                      │
-│    ├─ SAVED_HASH → CURRENT_HASH                             │
-│    ├─ Update codeSignatureText                              │
-│    ├─ Update lastUpdated timestamp                          │
-│    └─ Save updated map                                      │
-└────────────────┬────────────────────────────────────────────┘
-                 │
-                 ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 6. TypeScript: Git operations (if --auto-commit)            │
+│ 5. TypeScript: Git operations (if --auto-commit)            │
 │    ├─ git add docs/ doctype-map.json                        │
 │    ├─ git commit -m "🤖 Doctype: Auto-fix..."              │
 │    └─ git push (if configured)                              │
@@ -475,6 +492,7 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
 - `--no-ai` - Use placeholder instead of AI generation
 
 ---
+
 
 ## Design Decisions
 
@@ -497,6 +515,7 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
 
 ---
 
+
 ### Why TypeScript for AI and Orchestration?
 
 #### Developer Experience
@@ -515,6 +534,7 @@ function buildMarkdownFromStructure(doc: DocumentationStructure): string {
 - **Git integration**: simple-git for version control operations
 
 ---
+
 
 ### Why Structured JSON Output?
 
@@ -541,6 +561,7 @@ Template → "**Purpose:** Login user\n\n**Usage:**\n```typescript\nlogin();\n``
 
 ---
 
+
 ### Why Not Use Rust GenAI Module?
 
 **Initial Plan:** Implement AI calls in Rust
@@ -557,6 +578,7 @@ Template → "**Purpose:** Login user\n\n**Usage:**\n```typescript\nlogin();\n``
 **Result:** Rust handles compute-intensive tasks (parsing, hashing), TypeScript handles I/O and user interaction
 
 ---
+
 
 ## Data Model
 
@@ -598,6 +620,7 @@ Template → "**Purpose:** Login user\n\n**Usage:**\n```typescript\nlogin();\n``
 
 ---
 
+
 ## Performance Characteristics
 
 ### File Discovery
@@ -620,13 +643,15 @@ Template → "**Purpose:** Login user\n\n**Usage:**\n```typescript\nlogin();\n``
 
 **Bottleneck:** Negligible (crypto is fast in Rust)
 
-### AI Generation
+### AI Generation (Parallelized)
 - **Per symbol**: ~2-5s (network + LLM)
-- **Batch (10 symbols)**: ~3-8s (parallelized)
+- **Concurrency**: 5 parallel requests
+- **Orchestration**: Processing is batched in parallel, but file writing is sequential per file for safety.
 
 **Bottleneck:** API latency (network + LLM inference time)
 
 ---
+
 
 ## Future Enhancements
 
@@ -653,6 +678,7 @@ Template → "**Purpose:** Login user\n\n**Usage:**\n```typescript\nlogin();\n``
    - Rust support (using syn crate)
 
 ---
+
 
 ## Conclusion
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,10 @@ doctype init
 This will:
 - Prompt you for project configuration (name, root, docs folder)
 - **Automatically scan your TypeScript codebase** for exported symbols
-- **Create documentation files** based on your chosen strategy (Mirror, Module, or Type)
+- **Create documentation files** with "TODO" placeholders based on your chosen strategy
 - Generate SHA256 hashes of all code signatures
 - Create `doctype-map.json` to track everything (commit this file)
 - Create `doctype.config.json` with your project configuration (commit this file)
-- Optionally select an AI provider and configure its API key for AI-powered updates
 
 **Doctype will create documentation files with anchors like this:**
 
@@ -69,11 +68,17 @@ This will:
 <!-- doctype:end id="550e8400-e29b-41d4-a716-446655440000" -->
 ```
 
-**After running init, you can:**
-1. Manually fill in the documentation between the anchor tags, OR
-2. Use `doctype generate` (planned) to auto-generate initial content with AI
+### 3. Generate Content
 
-### 3. Check for Drift
+Once initialized, generate the actual documentation content using AI:
+
+```bash
+doctype generate
+```
+
+This command scans for "TODO" placeholders and uses your configured AI provider to write comprehensive documentation for each symbol.
+
+### 4. Check for Drift
 
 ```bash
 doctype check
@@ -84,7 +89,7 @@ doctype check
 ✓ All documentation is in sync with code
 ```
 
-### 4. Update Code, Fix Docs
+### 5. Update Code, Fix Docs
 
 Change your code:
 ```typescript
@@ -141,7 +146,6 @@ doctype init
 5. Generates SHA256 hashes of all code signatures
 6. Creates `doctype-map.json` to track everything (commit this)
 7. Creates `doctype.config.json` with project configuration (commit this)
-8. Optionally configures your selected AI provider's API key
 
 **Initial anchors are created with TODO placeholders:**
 ```markdown
@@ -150,7 +154,28 @@ doctype init
 <!-- doctype:end id="uuid" -->
 ```
 
-You can then manually document each symbol, or use `doctype generate` (planned) to auto-fill with AI.
+You can then manually document each symbol, or use `doctype generate` to auto-fill with AI.
+
+### `doctype generate`
+
+Generate documentation content using AI.
+
+```bash
+doctype generate
+```
+
+**Options:**
+- `--dry-run` - Preview generation without writing files
+- `--auto-commit` - Automatically commit changes to git
+- `--no-ai` - Use placeholder content instead of AI generation
+- `--verbose` - Show detailed output
+
+**What it does:**
+1. Scans for "TODO" placeholders in your documentation
+2. Detects documentation drift (out of sync code)
+3. Sends code context to your AI provider
+4. Injects intelligent, generated documentation
+5. Updates `doctype-map.json` hashes
 
 ### `doctype check`
 
@@ -384,13 +409,15 @@ Doctype uses your selected AI provider:
 
 ### What if I don't want to use AI?
 
-The `--no-ai` flag is designed for **testing CI/CD pipelines** without consuming tokens:
+You can manually edit the documentation files. Doctype will still track changes and warn you (via `doctype check`) if your manual documentation gets out of sync with the code.
+
+If you want to use the tooling but skip AI generation during updates, use the `--no-ai` flag:
 
 ```bash
-doctype fix --no-ai --dry-run
+doctype fix --no-ai
 ```
 
-**Important:** `--no-ai` does not actually update documentation content - it only tests the pipeline. For real documentation updates, you need AI (OpenAI) or manual editing.
+This will update the `doctype-map.json` hashes but inject a placeholder instead of AI content.
 
 ### Can I use this without an AI provider?
 

--- a/packages/cli/fix-orchestrator.ts
+++ b/packages/cli/fix-orchestrator.ts
@@ -1,0 +1,354 @@
+/**
+ * Fix Orchestrator - Core business logic for applying fixes/generations
+ *
+ * Centralizes the logic for:
+ * - Initializing AI Agent
+ * - looping through drifts
+ * - Generating content (AI or placeholder)
+ * - Injecting content
+ * - Updating the map
+ * - Auto-committing
+ */
+
+import { DoctypeMapManager } from '../content/map-manager';
+import { ContentInjector } from '../content/content-injector';
+import { extractAnchors, DoctypeAnchor } from '@doctypedev/core';
+import { Logger } from './logger';
+import { FixResult, FixOptions, FixDetail } from './types';
+import { DriftInfo } from './drift-detector';
+import { createAgentFromEnv, AIAgent } from '../ai';
+import { GitHelper } from './git-helper';
+import { existsSync, readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { getMapPath } from './config-loader';
+import { DoctypeConfig } from './types';
+
+/**
+ * Helper function to limit concurrency
+ */
+async function pMap<T, R>(
+    items: T[],
+    mapper: (item: T) => Promise<R>,
+    concurrency: number
+): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    let index = 0;
+    const execThread = async (): Promise<void> => {
+        while (index < items.length) {
+            const curIndex = index++;
+            results[curIndex] = await mapper(items[curIndex]);
+        }
+    };
+    const threads = [];
+    for (let i = 0; i < concurrency; i++) {
+        threads.push(execThread());
+    }
+    await Promise.all(threads);
+    return results;
+}
+
+/**
+ * Result of a generation task
+ */
+interface GenerationResult {
+    drift: DriftInfo;
+    content: string;
+    success: boolean;
+    error?: string;
+}
+
+/**
+ * Execute a list of fixes (or generations)
+ *
+ * @param drifts - List of drifts to fix
+ * @param mapManager - Map manager instance
+ * @param options - CLI options
+ * @param config - Doctype configuration
+ * @param logger - Logger instance
+ * @param actionLabel - Label for the action (e.g. "Updated", "Generated")
+ */
+export async function executeFixes(
+  drifts: DriftInfo[],
+  mapManager: DoctypeMapManager,
+  options: FixOptions,
+  config: DoctypeConfig | undefined,
+  logger: Logger,
+  actionLabel: string = 'Updated'
+): Promise<FixResult> {
+  // Initialize AI Agent if API key is available
+  let aiAgent: AIAgent | null = null;
+  let useAI = false;
+
+  if (!options.noAI) {
+    try {
+      aiAgent = createAgentFromEnv({ debug: options.verbose });
+      const isConnected = await aiAgent.validateConnection();
+
+      if (isConnected) {
+        useAI = true;
+        logger.info(`Using AI provider: ${aiAgent.getProvider()}`);
+      } else {
+        logger.warn('AI provider connection failed, falling back to placeholder content');
+      }
+    } catch (error) {
+      if (options.verbose) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger.debug(`AI initialization failed: ${errorMsg}`);
+      }
+      logger.info('No AI API key found, using placeholder content');
+    }
+  } else {
+    logger.info('AI generation disabled (--no-ai flag)');
+  }
+
+  const fixes: FixDetail[] = [];
+  let successCount = 0;
+  let failCount = 0;
+
+  // Determine map path and project base
+  const mapPath = options.map ? resolve(options.map) : getMapPath(config!);
+  const projectBase = config ? (config.baseDir || process.cwd()) : dirname(mapPath);
+
+  // Phase 1: Generation (Parallel)
+  logger.info(`Processing ${drifts.length} items with concurrency limit...`);
+  
+  const generateTask = async (drift: DriftInfo): Promise<GenerationResult> => {
+      const { entry, currentSignature, oldSignature } = drift;
+      
+      // Log start (debounced/limited by pMap, but still good to know)
+      // logger.debug(`Processing ${entry.codeRef.symbolName}...`);
+
+      try {
+          let newContent: string;
+
+          if (useAI && aiAgent) {
+              try {
+                  // Read current markdown content from file for AI context
+                  // Note: Reading file here is safe as we are just reading for context.
+                  // However, for high concurrency, reading same file multiple times might be redundant but safe.
+                  const docFilePath = resolve(projectBase, entry.docRef.filePath);
+                  let currentMarkdownContent = '';
+
+                  if (existsSync(docFilePath)) {
+                      const docContent = readFileSync(docFilePath, 'utf-8');
+                      const extractionResult = extractAnchors(docFilePath, docContent);
+                      const anchor = extractionResult.anchors.find((a: DoctypeAnchor) => a.id === entry.id);
+                      if (anchor) {
+                          currentMarkdownContent = anchor.content;
+                      }
+                  }
+
+                  if (oldSignature) {
+                      newContent = await aiAgent.generateFromDrift(
+                          entry.codeRef.symbolName,
+                          oldSignature,
+                          currentSignature,
+                          currentMarkdownContent,
+                          entry.codeRef.filePath
+                      );
+                  } else {
+                      newContent = await aiAgent.generateInitial(
+                          entry.codeRef.symbolName,
+                          currentSignature,
+                          {
+                              includeExamples: true,
+                              style: 'detailed',
+                          }
+                      );
+                  }
+              } catch (aiError) {
+                  const errorMsg = aiError instanceof Error ? aiError.message : String(aiError);
+                  logger.warn(`AI generation failed for ${entry.codeRef.symbolName}: ${errorMsg}`);
+                  newContent = generatePlaceholderContent(entry.codeRef.symbolName, currentSignature.signatureText);
+              }
+          } else {
+              newContent = generatePlaceholderContent(entry.codeRef.symbolName, currentSignature.signatureText);
+          }
+
+          return { drift, content: newContent, success: true };
+      } catch (error) {
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          return { drift, content: '', success: false, error: errorMsg };
+      }
+  };
+
+  const results = await pMap(drifts, generateTask, 5); // Concurrency limit 5
+
+  // Phase 2: Application (Sequential per file)
+  const injector = new ContentInjector();
+  
+  // Group results by doc file path
+  const resultsByFile = new Map<string, GenerationResult[]>();
+  for (const res of results) {
+      const docPath = resolve(projectBase, res.drift.entry.docRef.filePath);
+      if (!resultsByFile.has(docPath)) {
+          resultsByFile.set(docPath, []);
+      }
+      resultsByFile.get(docPath)!.push(res);
+  }
+
+  for (const [docPath, fileResults] of resultsByFile.entries()) {
+      // logger.debug(`Updating ${fileResults.length} entries in ${docPath}`);
+      
+      // We process updates for a single file sequentially to avoid race conditions
+      // ContentInjector reads file, modifies, returns result. 
+      // Ideally we should read once, apply all patches, write once.
+      // But ContentInjector.injectIntoFile is designed for single atomic operation (Read-Modify-Write).
+      // So calling it sequentially is safe but inefficient (multiple I/O).
+      // However, it IS safe because it writes sync.
+      
+      for (const res of fileResults) {
+          const { drift, content, success, error } = res;
+          const { entry, currentSignature } = drift;
+
+          if (!success) {
+              failCount++;
+              logger.error(`Failed to generate for ${entry.codeRef.symbolName}: ${error}`);
+              fixes.push({
+                  id: entry.id,
+                  symbolName: entry.codeRef.symbolName,
+                  codeFilePath: entry.codeRef.filePath,
+                  docFilePath: entry.docRef.filePath,
+                  success: false,
+                  error: error,
+              });
+              continue;
+          }
+
+          try {
+              const writeToFile = !options.dryRun;
+              // This is synchronous I/O, so it blocks. Safe for sequential loop.
+              const result = injector.injectIntoFile(docPath, entry.id, content, writeToFile);
+
+              if (result.success) {
+                  successCount++;
+                  // Only log if verbose or strict need
+                  logger.success(`${actionLabel} ${entry.codeRef.symbolName} (${result.linesChanged} lines)`);
+
+                  if (!options.dryRun) {
+                      const newHash = currentSignature.hash!;
+                      mapManager.updateEntry(entry.id, {
+                          codeSignatureHash: newHash,
+                          codeSignatureText: currentSignature.signatureText,
+                      });
+                  }
+
+                  fixes.push({
+                      id: entry.id,
+                      symbolName: entry.codeRef.symbolName,
+                      codeFilePath: entry.codeRef.filePath,
+                      docFilePath: entry.docRef.filePath,
+                      success: true,
+                      newContent: content,
+                  });
+              } else {
+                  failCount++;
+                  logger.error(`Failed to inject ${entry.codeRef.symbolName}: ${result.error}`);
+                  fixes.push({
+                      id: entry.id,
+                      symbolName: entry.codeRef.symbolName,
+                      codeFilePath: entry.codeRef.filePath,
+                      docFilePath: entry.docRef.filePath,
+                      success: false,
+                      error: result.error,
+                  });
+              }
+          } catch (e) {
+              failCount++;
+              const msg = e instanceof Error ? e.message : String(e);
+              logger.error(`Error writing ${entry.codeRef.symbolName}: ${msg}`);
+              fixes.push({
+                  id: entry.id,
+                  symbolName: entry.codeRef.symbolName,
+                  codeFilePath: entry.codeRef.filePath,
+                  docFilePath: entry.docRef.filePath,
+                  success: false,
+                  error: msg,
+              });
+          }
+      }
+  }
+
+  // Save updated map
+  if (!options.dryRun && successCount > 0) {
+    logger.debug('Saving updated doctype-map.json');
+    mapManager.save();
+  }
+
+  // Summary
+  logger.newline();
+  logger.divider();
+
+  if (successCount > 0) {
+    logger.success(`Successfully ${actionLabel.toLowerCase()} ${successCount} ${successCount === 1 ? 'entry' : 'entries'}`);
+  }
+
+  if (failCount > 0) {
+    logger.error(`Failed to ${actionLabel.toLowerCase()} ${failCount} ${failCount === 1 ? 'entry' : 'entries'}`);
+  }
+
+  if (options.dryRun) {
+    logger.info('Dry run complete - no files were modified');
+  } else if (options.autoCommit && successCount > 0) {
+    // Auto-commit functionality
+    logger.newline();
+    logger.info('Auto-committing changes...');
+
+    const gitHelper = new GitHelper(logger);
+
+    // Collect all modified files
+    const modifiedFiles = new Set<string>();
+    for (const fix of fixes) {
+      if (fix.success) {
+        modifiedFiles.add(fix.docFilePath);
+      }
+    }
+
+    // Add doctype-map.json
+    modifiedFiles.add(mapPath);
+
+    // Get symbol names for commit message
+    const symbolNames = fixes
+      .filter(f => f.success)
+      .map(f => f.symbolName);
+
+    // Commit changes
+    const commitResult = gitHelper.autoCommit(
+      Array.from(modifiedFiles),
+      symbolNames,
+      false // Don't push by default
+    );
+
+    if (commitResult.success) {
+      logger.success('Changes committed successfully');
+      if (commitResult.output) {
+        logger.info(`Commit message: "${commitResult.output}"`);
+      }
+    } else {
+      logger.error(`Auto-commit failed: ${commitResult.error}`);
+      logger.info('You can manually commit the changes');
+    }
+  }
+
+  logger.divider();
+
+  return {
+    totalFixes: fixes.length,
+    successfulFixes: successCount,
+    failedFixes: failCount,
+    fixes,
+    success: failCount === 0,
+  };
+}
+
+/**
+ * Generate placeholder content for documentation
+ */
+function generatePlaceholderContent(symbolName: string, signature: string): string {
+  return `**${symbolName}** - Documentation needs generation\n\n` +
+         `Current signature:\n` +
+         `\`\`\`typescript\n` +
+         `${signature}\n` +
+         `\`\`\`\n\n` +
+         `*This content is a placeholder. Run 'doctype generate' with a valid AI API key to generate full documentation.*`;
+}

--- a/packages/cli/generate.ts
+++ b/packages/cli/generate.ts
@@ -1,0 +1,180 @@
+/**
+ * CLI command: generate
+ *
+ * Generates documentation content using AI.
+ * This is effectively a semantic alias for the 'fix' command but focused on content generation.
+ */
+
+import { DoctypeMapManager } from '../content/map-manager';
+import { AstAnalyzer, extractAnchors, DoctypeAnchor, CodeSignature } from '@doctypedev/core';
+import { Logger } from './logger';
+import { GenerateResult, GenerateOptions } from './types';
+import { detectDrift } from './drift-detector';
+import { existsSync, readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import {
+  loadConfig,
+  getMapPath,
+  ConfigNotFoundError,
+  InvalidConfigError,
+} from './config-loader';
+import { executeFixes } from './fix-orchestrator';
+
+/**
+ * Execute the generate command
+ */
+export async function generateCommand(options: GenerateOptions): Promise<GenerateResult> {
+  const logger = new Logger(options.verbose);
+
+  logger.header('✨ Doctype Generate - AI Documentation Generation');
+
+  // Load configuration file (required for all commands except init)
+  let config;
+  try {
+    config = loadConfig();
+    logger.debug(`Loaded config: project "${config.projectName}"`);
+  } catch (error) {
+    if (error instanceof ConfigNotFoundError || error instanceof InvalidConfigError) {
+      logger.error(error.message);
+      return {
+        totalFixes: 0,
+        successfulFixes: 0,
+        failedFixes: 0,
+        fixes: [],
+        success: false,
+        configError: error.message,
+      };
+    }
+    throw error;
+  }
+
+  // Get map path from config, or use CLI override
+  const mapPath = options.map
+    ? resolve(options.map)
+    : getMapPath(config);
+
+  logger.debug(`Using map file: ${mapPath}`);
+
+  // Validate map file exists
+  if (!existsSync(mapPath)) {
+    logger.error(`Map file not found: ${Logger.path(mapPath)}`);
+    logger.info('Run this command from your project root, or specify --map path');
+    return {
+      totalFixes: 0,
+      successfulFixes: 0,
+      failedFixes: 0,
+      fixes: [],
+      success: false,
+      configError: `Map file not found: ${mapPath}`,
+    };
+  }
+
+  // Load the map
+  const mapManager = new DoctypeMapManager(mapPath);
+  const entries = mapManager.getEntries();
+
+  if (entries.length === 0) {
+    logger.warn('No entries found in doctype-map.json');
+    return {
+      totalFixes: 0,
+      successfulFixes: 0,
+      failedFixes: 0,
+      fixes: [],
+      success: true,
+    };
+  }
+
+  logger.info(`Analyzing ${entries.length} documentation entries...`);
+  logger.newline();
+
+  // Resolve the root directory for source code
+  const codeRoot = config 
+    ? resolve(config.baseDir || process.cwd(), config.projectRoot)
+    : dirname(mapPath);
+
+  // Detect drift (which includes missing content for new entries)
+  const analyzer = new AstAnalyzer();
+  const detectedDrifts = detectDrift(mapManager, analyzer, {
+    logger,
+    basePath: codeRoot,
+  });
+
+  // Second pass: Scan for "TODO" placeholders even if hashes match
+  // This enables "doctype generate" to work after "doctype init"
+  const driftedIds = new Set(detectedDrifts.map(d => d.entry.id));
+  const projectBase = config ? (config.baseDir || process.cwd()) : dirname(mapPath);
+  
+  // We need to re-analyze files to get signatures if we find placeholders
+  // Optimization: Only analyze if we find a placeholder
+  
+  for (const entry of entries) {
+    if (driftedIds.has(entry.id)) {
+      continue;
+    }
+
+    const docFilePath = resolve(projectBase, entry.docRef.filePath);
+    if (!existsSync(docFilePath)) {
+      continue;
+    }
+
+    try {
+      const docContent = readFileSync(docFilePath, 'utf-8');
+      const extractionResult = extractAnchors(docFilePath, docContent);
+      const anchor = extractionResult.anchors.find((a: DoctypeAnchor) => a.id === entry.id);
+      
+      if (anchor && anchor.content.includes('TODO: Add documentation for this symbol')) {
+        logger.debug(`Found placeholder for ${entry.codeRef.symbolName}, marking for generation`);
+        
+        // We need the current signature to generate content
+        const codeFilePath = resolve(projectBase, entry.codeRef.filePath);
+        if (existsSync(codeFilePath)) {
+           const signatures = analyzer.analyzeFile(codeFilePath);
+           const currentSignature = signatures.find((s: CodeSignature) => s.symbolName === entry.codeRef.symbolName);
+           
+           if (currentSignature) {
+             detectedDrifts.push({
+               entry,
+               currentSignature,
+               currentHash: currentSignature.hash!,
+               oldHash: entry.codeSignatureHash,
+               // No old signature needed as context since it's a new generation
+             });
+             driftedIds.add(entry.id);
+           }
+        }
+      }
+    } catch (e) {
+      // Ignore read errors
+    }
+  }
+
+  if (detectedDrifts.length === 0) {
+    logger.success('All documentation is up to date! Nothing to generate.');
+    return {
+      totalFixes: 0,
+      successfulFixes: 0,
+      failedFixes: 0,
+      fixes: [],
+      success: true,
+    };
+  }
+
+  logger.info(`Found ${detectedDrifts.length} ${detectedDrifts.length === 1 ? 'entry' : 'entries'} needing generation/update`);
+
+  if (options.dryRun) {
+    logger.warn('Dry run mode - no files will be modified');
+  }
+
+  logger.newline();
+  logger.divider();
+
+  // Execute fixes using the orchestrator
+  return await executeFixes(
+    detectedDrifts,
+    mapManager,
+    options,
+    config,
+    logger,
+    'Generated/Updated'
+  );
+}

--- a/packages/cli/types.ts
+++ b/packages/cli/types.ts
@@ -133,6 +133,16 @@ export interface InitOptions {
 }
 
 /**
+ * Options for the generate command (extends FixOptions)
+ */
+export interface GenerateOptions extends FixOptions {}
+
+/**
+ * Result of a generate operation (extends FixResult)
+ */
+export interface GenerateResult extends FixResult {}
+
+/**
  * Result of an init operation
  */
 export interface InitResult {


### PR DESCRIPTION
- `doctype init`: Removed AI provider prompts and AIAgent initialization. Now purely handles configuration and file scaffolding using "TODO" placeholders. Correctly computes and stores real hashes to allow manual documentation without drift errors.
- `doctype generate`: Added new command dedicated to AI content generation.
- Triggers on standard drift (hash mismatch).
- Triggers on detection of "TODO" placeholders in documentation files.
- Supports --verbose, --dry-run, and --no-ai options.
- Refactoring: Centralized fix and generation logic into fix-orchestrator.ts to eliminate code duplication between fix and generate commands.
- `doctype fix`: Now delegates execution to the centralized orchestrator.