### PR TITLE
feat: Preserve existing markdown anchor IDs by clearing and rebuilding the Doctype map.

### DIFF
--- a/.changeset/clever-eagles-eat.md
+++ b/.changeset/clever-eagles-eat.md
@@ -1,0 +1,6 @@
+---
+"@doctypedev/doctype": minor
+---
+
+- Enhance scanAndCreateAnchors function to handle existing markdown anchors more effectively
+- Improve error handling and reporting for anchor creation

--- a/packages/content/markdown-anchor-inserter.ts
+++ b/packages/content/markdown-anchor-inserter.ts
@@ -237,9 +237,18 @@ export class MarkdownAnchorInserter {
    * @returns Array of code references
    */
   public getExistingCodeRefs(content: string): string[] {
-    const pattern = /<!--\s*doctype:start\s+id="[^"]+"\s+code_ref="([^"]+)"\s*-->/g;
+    return this.getExistingAnchors(content).map(a => a.codeRef);
+  }
+
+  /**
+   * Get all existing anchors (ID and code ref) from markdown content
+   * @param content Markdown content
+   * @returns Array of anchor objects
+   */
+  public getExistingAnchors(content: string): Array<{ id: string; codeRef: string }> {
+    const pattern = /<!--\s*doctype:start\s+id="([^"]+)"\s+code_ref="([^"]+)"\s*-->/g;
     const matches = content.matchAll(pattern);
-    return Array.from(matches, (m) => m[1]);
+    return Array.from(matches, (m) => ({ id: m[1], codeRef: m[2] }));
   }
 
   /**


### PR DESCRIPTION
Closes #132 